### PR TITLE
Fix Magenta.js API usage for jazz guitar sound

### DIFF
--- a/jazz-trainer/index.html
+++ b/jazz-trainer/index.html
@@ -7,7 +7,7 @@
     <meta name="mobile-web-app-capable" content="yes">
     <title>Jazz Changes Trainer</title>
     <link rel="stylesheet" href="styles.css">
-    <script src="https://cdn.jsdelivr.net/npm/@magenta/music@1.23.1/es6/core.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/@magenta/music@1.23.1/dist/magentamusic.min.js"></script>
 </head>
 <body>
     <div class="container">


### PR DESCRIPTION
- Use magentamusic.min.js bundle instead of es6/core.js
- Use mm.SoundFontPlayer instead of core.SoundFontPlayer
- Use player.start(noteSequence) instead of playNoteDown()
- Use proper NoteSequence format for loadSamples()
- Remove unused audioContext references